### PR TITLE
Avoid reference error in plain browser environment

### DIFF
--- a/lib/asciidoc.js
+++ b/lib/asciidoc.js
@@ -4,7 +4,7 @@
     if (typeof exports == "object" && typeof module == "object") {
         // CommonJS
         mod(require("codemirror"));
-    } else if (brackets && brackets.getModule) {
+    } else if (typeof brackets == "object" && brackets.getModule) {
         // Brackets editor (using this as a client-side module!)
         mod(brackets.getModule("thirdparty/CodeMirror2/lib/codemirror"));
     } else if (typeof define == "function" && define.amd) {


### PR DESCRIPTION
I was seeing this: `Uncaught ReferenceError: brackets is not defined`.

I haven't tried this against brackets, so I'm just assuming `object`  is the correct type!
