### PR TITLE
feat: add CM6 support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ This repository contains the AsciiDoc mode for CodeMirror.
 $ npm install codemirror-asciidoc
 ```
 
-## Usage
+## Usage for CM5 with `codemirror-asciidoc@1.x`
 
 ```js
 var codemirror = require("codemirror"),
@@ -19,6 +19,21 @@ codemirror.fromTextArea(document.getElementById("editor"), {
   lineWrapping: true,
   mode: "asciidoc"
 });
+```
+
+## Usage for CM6 with `codemirror-asciidoc@2.x`
+
+```js
+import {StreamLanguage} from "@codemirror/stream-parser"
+import {asciidoc} from "codemirror-asciidoc/lib/asciidoc"
+
+import {EditorView, EditorState, basicSetup} from "@codemirror/basic-setup"
+
+let view = new EditorView({
+  state: EditorState.create({
+    extensions: [basicSetup, StreamLanguage.define(asciidoc)]
+  })
+})
 ```
 
 ## License

--- a/lib/asciidoc.cjs
+++ b/lib/asciidoc.cjs
@@ -1,3 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
 // Parts from Ace; see <https://raw.githubusercontent.com/ajaxorg/ace/master/LICENSE>
 // Ace highlight rules function imported below.
 var HighlightRules = function () {
@@ -380,7 +384,7 @@ var Tokenizer = function (rules) {
         } else if (parenOpen) {
           stack++;
           if (parenOpen.length != 1) {
-            lastCapture.stack = stack
+            lastCapture.stack = stack;
             lastCapture.start = index;
           }
         }
@@ -627,13 +631,13 @@ var matchToken = function (stream, state) {
 
   // Consume a token.
   return consumeToken(stream, state);
-}
+};
 
 // Initialize all state.
 var aceHighlightRules = new HighlightRules();
 var tokenizer = new Tokenizer(aceHighlightRules.$rules);
 
-export const asciidoc = {
+const asciidoc = {
   startState: function () {
     return {
       current: 'start',
@@ -646,3 +650,5 @@ export const asciidoc = {
   },
   token: matchToken
 };
+
+exports.asciidoc = asciidoc;

--- a/lib/asciidoc.d.ts
+++ b/lib/asciidoc.d.ts
@@ -1,0 +1,2 @@
+import {StreamParser} from "@codemirror/stream-parser"
+export declare const asciidoc: StreamParser<unknown>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemirror-asciidoc",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "description": "Asciidoc mode for CodeMirror",
   "homepage": "https://github.com/asciidoctor/codemirror-asciidoc",
   "author": "Harutyun Amirjanyan (https://github.com/nightwing)",


### PR DESCRIPTION
Hi;
I would like to use the library with CM6, 
I propose this migration which consists simply to manage the files in the same way as https://github.com/codemirror/legacy-modes